### PR TITLE
Automatic tests of LDPC code performance

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.19)
 
 project(LDPC4QKDLibrary)
 
+get_filename_component(LDPC4QKD_PROJ_DIR ${CMAKE_CURRENT_LIST_DIR} DIRECTORY)
+get_filename_component(LDPC4QKD_TESTS_DIR "${LDPC4QKD_PROJ_DIR}/tests" ABSOLUTE)
 
 if (NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/autogen_ldpc_matrix_csc.hpp")
     message(WARNING "C++ code containing the LDPC matrix not found.
@@ -9,9 +11,9 @@ if (NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/autogen_ldpc_matrix_csc.hpp")
 
     add_custom_command(
             OUTPUT autogen_ldpc_matrix_csc.hpp
-            DEPENDS "${CMAKE_SOURCE_DIR}/tests/fortest_autogen_ldpc_matrix_csc.hpp"
+            DEPENDS "${LDPC4QKD_TESTS_DIR}/fortest_autogen_ldpc_matrix_csc.hpp"
             COMMAND ${CMAKE_COMMAND} -E copy
-            "${CMAKE_SOURCE_DIR}/tests/fortest_autogen_ldpc_matrix_csc.hpp"
+            "${LDPC4QKD_TESTS_DIR}/fortest_autogen_ldpc_matrix_csc.hpp"
             "${CMAKE_CURRENT_LIST_DIR}/autogen_ldpc_matrix_csc.hpp"
             VERBATIM
     )
@@ -24,9 +26,9 @@ if (NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/autogen_rate_adaption.hpp")
 
     add_custom_command(
             OUTPUT autogen_rate_adaption.hpp
-            DEPENDS "${CMAKE_SOURCE_DIR}/tests/fortest_autogen_rate_adaption.hpp"
+            DEPENDS "${LDPC4QKD_TESTS_DIR}/fortest_autogen_rate_adaption.hpp"
             COMMAND ${CMAKE_COMMAND} -E copy
-            "${CMAKE_SOURCE_DIR}/tests/fortest_autogen_rate_adaption.hpp"
+            "${LDPC4QKD_TESTS_DIR}/fortest_autogen_rate_adaption.hpp"
             "${CMAKE_CURRENT_LIST_DIR}/autogen_rate_adaption.hpp"
             VERBATIM
     )

--- a/src/rate_adaptive_code.hpp
+++ b/src/rate_adaptive_code.hpp
@@ -157,6 +157,16 @@ namespace LDPC4QKD {
             }
         }
 
+        /// compute log-likelihood-ratios for a given keye and channel parameter
+        static std::vector<double> llrs_bsc(const std::vector<Bit> &bitstring, const double bsc_channel_parameter) {
+            double vlog = log((1 - bsc_channel_parameter) / bsc_channel_parameter);
+            std::vector<double> llrs(bitstring.size());
+            for (std::size_t i{}; i < llrs.size(); ++i) {
+                llrs[i] = vlog * (1 - 2 * bitstring[i]); // log likelihood ratios
+            }
+            return llrs;
+        }
+
         /// decoder infers rate from the length of the syndrome and changes the internal decoder state to match this rate.
         /// Note: since this function modifies the code (by performing rate adaption), it is NOT CONST.
         /// this change may be somewhat computationally expensive TODO benchmark this


### PR DESCRIPTION
The benchmarks should be run automatically. This is to determine the quality of provided codes and indicate what regimes of application they are suited for. These results should be plotted automatically.